### PR TITLE
fix: reserve 1024x768 canvas

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     --accent:#5dd3ff; --ok:#35d07f; --warn:#ffcc00; --bad:#ff5d6c;
   }
   html,body{height:100%;margin:0;background:var(--bg);color:var(--ink);font-family:system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji"}
-  .wrap{display:grid;grid-template-columns: 340px 1fr 340px;grid-template-rows:auto 1fr;gap:14px;height:100%;padding:14px;box-sizing:border-box}
+  .wrap{display:grid;grid-template-columns: 340px 1024px 340px;grid-template-rows:auto 768px;gap:14px;justify-content:center;height:100%;padding:14px;box-sizing:border-box}
   header{grid-column:1/-1;background:linear-gradient(135deg,#0f1b34,#0d203c 55%,#0d1a2b);border:1px solid #1f2b47;border-radius:14px;padding:12px 16px;display:flex;align-items:center;justify-content:space-between}
   header h1{font-size:18px;margin:0;font-weight:650}
   header .sub{color:var(--muted);font-size:12px}
@@ -22,7 +22,7 @@
   label{font-size:12px;color:var(--muted)}
   input[type=range]{width:100%}
   .val{min-width:90px;text-align:right;font-variant-numeric:tabular-nums}
-  .canvasWrap{position:relative;height:100%}
+  .canvasWrap{position:relative;width:1024px;height:768px}
   #view{width:100%;height:100%;display:block;background:conic-gradient(from 180deg at 50% 50%,#0a1326,#0a152a,#0b1a35 60%,#0b1830);border-radius:12px}
   /* Mouse feedback */
   canvas.grab{cursor:grab}


### PR DESCRIPTION
## Summary
- allocate a fixed 1024x768 area for the sail visualisation
- center the main layout for better screen use

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899efa706188329bb47d9ea6b9b7906