### PR TITLE
Rotate view around mast axis

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,14 +177,21 @@
   const cam = { scale: 1, rot: 0, panX: 0, panY: 0 }; // pan in CSS pixels * DPR
   function resetCam(){ cam.scale=1; cam.rot=0; cam.panX=0; cam.panY=0; }
 
+  function mastPivot(){
+    const g = sailPath();
+    return { x: g.tack.x, y: (g.tack.y + g.mastHead.y) / 2 };
+  }
+
   function worldToScreen(wx, wy){
-    const cx=W*0.5, cy=H*0.5; const cosR=Math.cos(cam.rot), sinR=Math.sin(cam.rot);
+    const {x:cx, y:cy} = mastPivot();
+    const cosR=Math.cos(cam.rot), sinR=Math.sin(cam.rot);
     const x=(wx-cx)*cam.scale; const y=(wy-cy)*cam.scale;
     const xr=x*cosR - y*sinR; const yr=x*sinR + y*cosR;
     return { x:xr + cx + cam.panX, y:yr + cy + cam.panY };
   }
   function screenToWorld(sx, sy){
-    const cx=W*0.5, cy=H*0.5; const cosR=Math.cos(cam.rot), sinR=Math.sin(cam.rot);
+    const {x:cx, y:cy} = mastPivot();
+    const cosR=Math.cos(cam.rot), sinR=Math.sin(cam.rot);
     let x=sx - cam.panX - cx; let y=sy - cam.panY - cy;
     const xr=x*cosR + y*sinR; const yr=-x*sinR + y*cosR;
     return { x:xr / cam.scale + cx, y:yr / cam.scale + cy };
@@ -337,18 +344,19 @@
     ctx.restore();
 
     const bands = compute();
+    const g = sailPath();
+    const pivotX = g.tack.x;
+    const pivotY = (g.tack.y + g.mastHead.y) / 2;
 
     // ===== Apply camera transform for sail drawing =====
     ctx.save();
-    const cx = W*0.5, cy = H*0.5;
     ctx.translate(cam.panX, cam.panY);
-    ctx.translate(cx, cy);
+    ctx.translate(pivotX, pivotY);
     ctx.rotate(cam.rot);
     ctx.scale(cam.scale, cam.scale);
-    ctx.translate(-cx, -cy);
+    ctx.translate(-pivotX, -pivotY);
 
     // Sail outline
-    const g = sailPath();
     ctx.beginPath();
     ctx.moveTo(g.tack.x, g.tack.y);
     ctx.lineTo(g.clew.x, g.clew.y);


### PR DESCRIPTION
## Summary
- Rotate camera around the mast line instead of the canvas center
- Adjust transformation matrix to keep mast as pivot during interaction

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899f856aae08329b7a29fcc18aad5bc